### PR TITLE
Add option to skip MFA for vpn_auth connections

### DIFF
--- a/duo_openvpn_as.py
+++ b/duo_openvpn_as.py
@@ -16,6 +16,9 @@ HOST = '<DUO API HOSTNAME HERE>'
 PROXY_HOST = ''
 PROXY_PORT = 8080
 
+# To skip MFA for VPN connections, set the following to True:
+SKIP_DUO_ON_VPN_AUTH = False
+
 # ------------------------------------------------------------------
 
 import syslog
@@ -489,6 +492,9 @@ def post_auth_cr(authcred, attributes, authret, info, crstate):
     #   again using the session token.
 
     if info.get('auth_method') in ('session', 'autologin'):
+        return authret
+
+    if SKIP_DUO_ON_VPN_AUTH and attributes.get('vpn_auth'):
         return authret
 
     username = authcred['username']


### PR DESCRIPTION
For our use case, we found it was best to force Duo secondary authentication for logins via the web UI (user & admin login) but skip the hassle of the challenge / response flow when a certificate is presented for vpn_auth.

This diff adds a new global setting `SKIP_DUO_ON_VPN_AUTH` that shortcuts the need for MFA if `vpn_auth` is True in the attributes dictionary. The original script behavior is the default.
