### PR TITLE
Check for Google Authenticator status

### DIFF
--- a/duo_openvpn_as.py
+++ b/duo_openvpn_as.py
@@ -20,6 +20,8 @@ PROXY_PORT = 8080
 # connections. Two-factor will only be required for other
 # authentications (like web server access).
 SKIP_DUO_ON_VPN_AUTH = False
+# Set to True if GOOGLE_AUTH is globally enabled
+GLOBAL_GOOGLE_AUTH = False
 
 # ------------------------------------------------------------------
 
@@ -602,6 +604,16 @@ def post_auth_cr(authcred, attributes, authret, info, crstate):
 
     if SKIP_DUO_ON_VPN_AUTH and attributes.get('vpn_auth'):
         return authret
+
+    # Don't do challenge/response on users with Google Authenticator
+    # enabled globally or per user/group as crstate will be undefined.
+    if 'prop_google_auth' in authret['proplist']:
+        if authret['proplist']['prop_google_auth'] == True:
+            return authret
+    
+    if GLOBAL_GOOGLE_AUTH:
+        if ('prop_google_auth' not in authret['proplist']):
+            return authret
 
     username = authcred['username']
     ipaddr = authcred['client_ip_addr']

--- a/duo_openvpn_as.py
+++ b/duo_openvpn_as.py
@@ -20,7 +20,7 @@ PROXY_PORT = 8080
 # connections. Two-factor will only be required for other
 # authentications (like web server access).
 SKIP_DUO_ON_VPN_AUTH = False
-# Set to True if GOOGLE_AUTH is globally enabled
+# Set to True if value of "vpn.server.google_auth.enable" is True
 GLOBAL_GOOGLE_AUTH = False
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
Noticed that post_auth throws a NoneType exception at `if crstate.get('challenge'):` if Google Authenticator is enabled. These changes allow for assumption of Globally enabled Google Auth with user/group disable property for transitioning to Duo as well as just mixing the two if required.