### PR TITLE
Attempt sending Duo "push" response automatically

### DIFF
--- a/duo_openvpn_as.py
+++ b/duo_openvpn_as.py
@@ -640,7 +640,10 @@ def post_auth_cr(authcred, attributes, authret, info, crstate):
     #   a session token.  The client is attempting to authenticate
     #   again using the session token.
 
-    if info.get('auth_method') in ('session', 'autologin'):
+    auth_method = info.get('auth_method')
+    if auth_method in ('session', 'autologin'):
+        log("skipping auth method=%s" % auth_method)
+
         return authret
 
     if SKIP_DUO_ON_VPN_AUTH and attributes.get('vpn_auth'):

--- a/duo_openvpn_as.py
+++ b/duo_openvpn_as.py
@@ -722,8 +722,10 @@ def post_auth_cr(authcred, attributes, authret, info, crstate):
                 # when the preauth result comes back as requiring authentication
                 # try to automatically respond to this with the "push" key
                 if AUTOPUSH:
-                    log("Autopushing user: {0}".format(username))
                     autopush_factor = response.factors.get('default')
+
+                    log("Autopushing user: %s, autopush_factor=%s" % (username, autopush_factor))
+
                     authret = auth_and_update_result_structure(username, autopush_factor, ipaddr, authret)
                 else:
                     log("prompt for challenge")


### PR DESCRIPTION
99% of the time, the Duo challenge response is going to be `push` when connecting to the VPN, and the code should try this automatically.

This patch sends the push response automatically and will fallback to prompting the user when that fails.