### PR TITLE
use client_ip_addr safely

### DIFF
--- a/duo_openvpn_as.py
+++ b/duo_openvpn_as.py
@@ -520,8 +520,11 @@ class OpenVPNIntegration(Client):
 
         params = {
             'user': username,
-            'ipaddr': ipaddr,
         }
+
+        if ipaddr:
+            params['ipaddr'] = ipaddr
+      
 
         response = self.json_api_call('POST', '/rest/v1/preauth', params)
 
@@ -562,8 +565,11 @@ class OpenVPNIntegration(Client):
             'user': username,
             'factor': 'auto',
             'auto': password,
-            'ipaddr': ipaddr
         }
+
+        if ipaddr:
+            params['ipaddr'] = ipaddr
+        
 
         response = self.json_api_call('POST', '/rest/v1/auth', params)
 
@@ -604,7 +610,7 @@ def post_auth_cr(authcred, attributes, authret, info, crstate):
         return authret
 
     username = authcred['username']
-    ipaddr = authcred['client_ip_addr']
+    ipaddr = authcred.get('client_ip_addr')
 
     if crstate.get('challenge'):
         # response to dynamic challenge


### PR DESCRIPTION
OpenVPN Access Server typically provides the client_ip_addr in post_auth. However, there are some cases where the client_ip_addr is not present.

Since the duo security post auth script assumes that the client_ip_addr is always present and therefore will throw an exception when it is not provided causing the post auth to not authenticate the user. 

This fix address two issues:
1. Gets the client_ip_addr safely so that if it is not provided, the ip_addr is then set to None, otherwise it is set to client_ip_addr

2. Since the ip_addr field is optional in both auth and preauth API, the ip_addr is include in the API only if it is available in post_auth. Otherwise, it is not include in the API call