### PR TITLE
Fix user record is not created in the AS after the login

### DIFF
--- a/duo_openvpn_as.py
+++ b/duo_openvpn_as.py
@@ -760,4 +760,6 @@ def post_auth_cr(authcred, attributes, authret, info, crstate):
             authret['client_reason'] = \
                 "Unknown error communicating with Duo service"
 
-    return authret
+    # if user needs to be created after the login, its props should be returned 
+    # as a second parameter from the function
+    return authret, authret.get('proplist')


### PR DESCRIPTION
Because of the recent changes in the AS user properties which has to be set in the DB should be returned as a second parameter in from the post_auth script function.