### PR TITLE
Use socket.create_connection for IPv6 support

### DIFF
--- a/duo_openvpn_as.py
+++ b/duo_openvpn_as.py
@@ -877,8 +877,7 @@ class CertValidatingHTTPSConnection(httplib.HTTPConnection):
 
   def connect(self):
     "Connect to a host on a given (SSL) port."
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.connect((self.host, self.port))
+    sock = socket.create_connection((self.host, self.port))
     self.sock = sock
     if self._tunnel_host:
       self._tunnel()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Previously, the connection was hardcoded to use `socket.AF_INET` , which is IPv4-only.
`socket.create_connection` is a higher-level replacement which supports both IPv4 and IPv6 https://docs.python.org/2/library/socket.html#socket.create_connection

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To ensure compatibility with IPv6 as the internet (eventually) moves to it.

## How Has This Been Tested?
Setup a local server using https://hub.docker.com/r/openvpn/openvpn-as with IPv4 disabled and successfully tested against an internal IPv6-enabled Duo test instance.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
